### PR TITLE
alsamixer: remove redundant and unused variable err

### DIFF
--- a/alsamixer/mixer_widget.c
+++ b/alsamixer/mixer_widget.c
@@ -444,7 +444,6 @@ static void balance_volumes(void)
 {
 	struct control *control;
 	double left, right;
-	int err;
 
 	control = get_focus_control(TYPE_PVOLUME | TYPE_CVOLUME);
 	if (!control || !(control->flags & HAS_VOLUME_1))


### PR DESCRIPTION
err is not being used, so remove it.

Signed-off-by: Colin Ian King <colin.king@canonical.com>